### PR TITLE
Refactor access resources map

### DIFF
--- a/src/main/java/eu/antidotedb/client/accessresources/Permissions.java
+++ b/src/main/java/eu/antidotedb/client/accessresources/Permissions.java
@@ -5,13 +5,13 @@ import eu.antidotedb.client.decision.S3Request;
 import java.util.Collection;
 
 /**
- *
+ * simplified ACL for management in decision procedure
  * @author romain-dumarais
  */
 public class Permissions implements S3AccessResource{
     private final Collection<ByteString> permissions;
 
-    Permissions(Collection<ByteString> permissions) {
+    public Permissions(Collection<ByteString> permissions) {
         this.permissions=permissions;
     }
 

--- a/src/main/java/eu/antidotedb/client/accessresources/S3AccessResource.java
+++ b/src/main/java/eu/antidotedb/client/accessresources/S3AccessResource.java
@@ -4,7 +4,7 @@ import eu.antidotedb.client.decision.S3Request;
 
 
 /**
- * 
+ * interface used in decision procedure to manage Policies & ACL
  * @author romain-dumarais
  */
 public interface S3AccessResource {

--- a/src/main/java/eu/antidotedb/client/accessresources/S3BucketACL.java
+++ b/src/main/java/eu/antidotedb/client/accessresources/S3BucketACL.java
@@ -6,6 +6,10 @@ import static eu.antidotedb.antidotepb.AntidotePB.CRDT_type.POLICY;
 import eu.antidotedb.client.S3InteractiveTransaction;
 import static eu.antidotedb.client.accessresources.S3Operation.WRITEBUCKETACL;
 import static eu.antidotedb.client.accessresources.S3Operation.READBUCKETACL;
+import static eu.antidotedb.client.accessresources.S3Operation.READOBJECT;
+import static eu.antidotedb.client.accessresources.S3Operation.READOBJECTACL;
+import static eu.antidotedb.client.accessresources.S3Operation.WRITEOBJECT;
+import static eu.antidotedb.client.accessresources.S3Operation.WRITEOBJECTACL;
 import eu.antidotedb.client.decision.AccessControlException;
 import java.util.Collection;
 import java.util.HashMap;
@@ -37,13 +41,15 @@ public class S3BucketACL extends S3ACL{
         Set<ByteString> rights = new HashSet<>();
         switch(right){
             case("writeACL"):
-                rights.add(ByteString.copyFromUtf8("writeACL"));
+                rights.add(ByteString.copyFromUtf8(WRITEBUCKETACL.toString()));
+                rights.add(ByteString.copyFromUtf8(WRITEOBJECTACL.toString()));
             case("readACL"):
-                rights.add(ByteString.copyFromUtf8("readACL"));
+                rights.add(ByteString.copyFromUtf8(READBUCKETACL.toString()));
+                rights.add(ByteString.copyFromUtf8(READOBJECTACL.toString()));
             case("write"):
-                rights.add(ByteString.copyFromUtf8("write"));
+                rights.add(ByteString.copyFromUtf8(WRITEOBJECT.toString()));
             case("read"):
-                rights.add(ByteString.copyFromUtf8("read"));
+                rights.add(ByteString.copyFromUtf8(READOBJECT.toString()));
             case("none"):
                 rights.add(ByteString.copyFromUtf8("none"));
             case("default"):

--- a/src/main/java/eu/antidotedb/client/accessresources/S3ObjectACL.java
+++ b/src/main/java/eu/antidotedb/client/accessresources/S3ObjectACL.java
@@ -4,7 +4,9 @@ import com.google.protobuf.ByteString;
 import eu.antidotedb.antidotepb.AntidotePB;
 import static eu.antidotedb.antidotepb.AntidotePB.CRDT_type.POLICY;
 import eu.antidotedb.client.S3InteractiveTransaction;
+import static eu.antidotedb.client.accessresources.S3Operation.READOBJECT;
 import static eu.antidotedb.client.accessresources.S3Operation.READOBJECTACL;
+import static eu.antidotedb.client.accessresources.S3Operation.WRITEOBJECT;
 import static eu.antidotedb.client.accessresources.S3Operation.WRITEOBJECTACL;
 import eu.antidotedb.client.decision.AccessControlException;
 import java.util.Collection;
@@ -39,13 +41,13 @@ public class S3ObjectACL extends S3ACL{
         Set<ByteString> rights = new HashSet<>();
         switch(right){
             case("writeACL"):
-                rights.add(ByteString.copyFromUtf8("writeACL"));
+                rights.add(ByteString.copyFromUtf8(WRITEOBJECTACL.toString()));
             case("readACL"):
-                rights.add(ByteString.copyFromUtf8("readACL"));
+                rights.add(ByteString.copyFromUtf8(READOBJECTACL.toString()));
             case("write"):
-                rights.add(ByteString.copyFromUtf8("write"));
+                rights.add(ByteString.copyFromUtf8(WRITEOBJECT.toString()));
             case("read"):
-                rights.add(ByteString.copyFromUtf8("read"));
+                rights.add(ByteString.copyFromUtf8(READOBJECT.toString()));
             case("none"):
                 rights.add(ByteString.copyFromUtf8("none"));
             case("default"):

--- a/src/main/java/eu/antidotedb/client/accessresources/S3Policy.java
+++ b/src/main/java/eu/antidotedb/client/accessresources/S3Policy.java
@@ -5,7 +5,6 @@ import com.eclipsesource.json.JsonArray;
 import com.eclipsesource.json.JsonObject;
 import com.eclipsesource.json.JsonValue;
 import com.google.protobuf.ByteString;
-import eu.antidotedb.client.S3InteractiveTransaction;
 import static eu.antidotedb.client.accessresources.S3Operation.*;
 import eu.antidotedb.client.decision.S3Request;
 import java.util.ArrayList;
@@ -21,7 +20,7 @@ import java.util.List;
  * TODO : statement for user policy management : currently needs a non-null bucket
  * @author romain-dumarais
  */
-public class S3Policy {
+public class S3Policy implements S3AccessResource{
 
     protected List<S3Statement> statements;
     protected List<ByteString> groups;

--- a/src/main/java/eu/antidotedb/client/decision/S3DecisionProcedure.java
+++ b/src/main/java/eu/antidotedb/client/decision/S3DecisionProcedure.java
@@ -52,7 +52,7 @@ public class S3DecisionProcedure /*implements DecisionProcedure*/ {
             if(resource.explicitDeny(request)){return false;}
         }
         for(S3AccessResource resource: accessResources.values()){
-            if(resource.explicitAllow(request)){return false;}
+            if(resource.explicitAllow(request)){return true;}
         }
         return false;
         /*
@@ -107,7 +107,7 @@ public class S3DecisionProcedure /*implements DecisionProcedure*/ {
             if(resource.explicitDeny(request)){return false;}
         }
         for(S3AccessResource resource: accessResources.values()){
-            if(resource.explicitAllow(request)){return false;}
+            if(resource.explicitAllow(request)){return true;}
         }
         return false;
         /*
@@ -156,7 +156,7 @@ public class S3DecisionProcedure /*implements DecisionProcedure*/ {
             if(resource.explicitDeny(request)){return false;}
         }
         for(S3AccessResource resource: accessResources.values()){
-            if(resource.explicitAllow(request)){return false;}
+            if(resource.explicitAllow(request)){return true;}
         }
         return false;
         /*
@@ -194,7 +194,7 @@ public class S3DecisionProcedure /*implements DecisionProcedure*/ {
             if(resource.explicitDeny(request)){return false;}
         }
         for(S3AccessResource resource: accessResources.values()){
-            if(resource.explicitAllow(request)){return false;}
+            if(resource.explicitAllow(request)){return true;}
         }
         return false;
 /*        
@@ -234,7 +234,7 @@ public class S3DecisionProcedure /*implements DecisionProcedure*/ {
             if(resource.explicitDeny(request)){return false;}
         }
         for(S3AccessResource resource: accessResources.values()){
-            if(resource.explicitAllow(request)){return false;}
+            if(resource.explicitAllow(request)){return true;}
         }
         return false;
         /*
@@ -280,7 +280,7 @@ public class S3DecisionProcedure /*implements DecisionProcedure*/ {
             if(resource.explicitDeny(request)){return false;}
         }
         for(S3AccessResource resource: accessResources.values()){
-            if(resource.explicitAllow(request)){return false;}
+            if(resource.explicitAllow(request)){return true;}
         }
         return false;
         /*
@@ -333,7 +333,7 @@ public class S3DecisionProcedure /*implements DecisionProcedure*/ {
             if(resource.explicitDeny(request)){return false;}
         }
         for(S3AccessResource resource: accessResources.values()){
-            if(resource.explicitAllow(request)){return false;}
+            if(resource.explicitAllow(request)){return true;}
         }
         return false;
         /*
@@ -365,7 +365,7 @@ public class S3DecisionProcedure /*implements DecisionProcedure*/ {
             if(resource.explicitDeny(request)){return false;}
         }
         for(S3AccessResource resource: accessResources.values()){
-            if(resource.explicitAllow(request)){return false;}
+            if(resource.explicitAllow(request)){return true;}
         }
         return false;
         /*
@@ -399,7 +399,7 @@ public class S3DecisionProcedure /*implements DecisionProcedure*/ {
             if(resource.explicitDeny(request)){return false;}
         }
         for(S3AccessResource resource: accessResources.values()){
-            if(resource.explicitAllow(request)){return false;}
+            if(resource.explicitAllow(request)){return true;}
         }
         return false;
         /*
@@ -425,7 +425,7 @@ public class S3DecisionProcedure /*implements DecisionProcedure*/ {
             if(resource.explicitDeny(request)){return false;}
         }
         for(S3AccessResource resource: accessResources.values()){
-            if(resource.explicitAllow(request)){return false;}
+            if(resource.explicitAllow(request)){return true;}
         }
         return false;
         /*


### PR DESCRIPTION
use a map of accessResource objects in the decision procedure to : 
- be able to add groups
- be able to merge w/ ACGreGate SecurityLayers semantics